### PR TITLE
FDV-89: Fix non-JSON response/request bodies not rendering in UI + add prettified headers for error responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,23 @@
-# CHANGELOG
+# Changelog
 
-## 1.0.0
+## 1.3.1
 
-- Initial version
+- Non-JSON responses/requests are now properly display in log details screen
+- Added pretty formatting for error response headers
+
+## 1.3.0
+
+- Redesigned log details screen
+- Small UI improvements & fixes
+- Update packages to latest:
+    - dio
+
+## 1.2.0
+
+- Add possibility to add proxy address
+- Update packages to latest:
+    - dio
+    - share_plus
 
 ## 1.1.0
 
@@ -11,16 +26,6 @@
   - dio
   - path_provider
 
-## 1.2.0
+## 1.0.0
 
-- Add possibility to add proxy address
-- Update packages to latest:
-  - dio
-  - share_plus
-
-## 1.3.0
-
-- Redesigned log details screen
-- Small UI improvements & fixes
-- Update packages to latest:
-  - dio
+- Initial version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.3.1
 
-- Non-JSON responses/requests are now properly display in log details screen
+- Non-JSON responses/requests are now properly displayed in log details screen
 - Added pretty formatting for error response headers
 
 ## 1.3.0

--- a/lib/src/network_logs/interceptor/network_logger_interceptor.dart
+++ b/lib/src/network_logs/interceptor/network_logger_interceptor.dart
@@ -84,7 +84,11 @@ class NetworkLoggerInterceptor extends Interceptor {
           responseBody: _prettyJson(err.response?.data),
           requestBody: _prettyJson(err.response?.requestOptions.data),
           responseHeaders: err.response?.headers.map.map(
-            (key, value) => MapEntry(key.toString(), value.toString()),
+            (key, value) {
+              final listValue = value.join(', ');
+              final prettyValue = _tryPrettyJsonHeader(listValue);
+              return MapEntry(key.toString(), prettyValue);
+            },
           ),
         ),
       );

--- a/lib/src/network_logs/widget/network_logs_details_page.dart
+++ b/lib/src/network_logs/widget/network_logs_details_page.dart
@@ -276,7 +276,7 @@ class _RequestTab extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final requestBody = log.requestBody;
-    final requestBodyIsPresent = requestBody != null && requestBody != 'null' && requestBody.isNotEmpty;
+    final requestBodyIsPresent = requestBody != null && requestBody != 'null' && requestBody.trim().isNotEmpty;
     final requestBodyIsJson = requestBodyIsPresent && JsonUtils.isJson(requestBody);
     final headers = log.requestHeaders.entries;
 
@@ -350,7 +350,7 @@ class _ResponseTab extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final responseBody = log.responseBody;
-    final responseBodyIsPresent = responseBody != null && responseBody != 'null' && responseBody.isNotEmpty;
+    final responseBodyIsPresent = responseBody != null && responseBody != 'null' && responseBody.trim().isNotEmpty;
     final responseBodyIsJson = responseBodyIsPresent && JsonUtils.isJson(responseBody);
     final headers = log.responseHeaders?.entries ?? {};
 

--- a/lib/src/network_logs/widget/network_logs_details_page.dart
+++ b/lib/src/network_logs/widget/network_logs_details_page.dart
@@ -3,6 +3,7 @@ import 'package:chili_debug_view/src/network_logs/model/network_log.dart';
 import 'package:chili_debug_view/src/share/share_provider.dart';
 import 'package:chili_debug_view/src/theme/typography/app_typography.dart';
 import 'package:chili_debug_view/src/time/time_provider.dart';
+import 'package:chili_debug_view/src/utils/json_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -275,6 +276,8 @@ class _RequestTab extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final requestBody = log.requestBody;
+    final requestBodyIsPresent = requestBody != null && requestBody != 'null' && requestBody.isNotEmpty;
+    final requestBodyIsJson = requestBodyIsPresent && JsonUtils.isJson(requestBody);
     final headers = log.requestHeaders.entries;
 
     return _ScrollableTab(
@@ -313,15 +316,17 @@ class _RequestTab extends StatelessWidget {
               'Body:',
               style: AppTypography.headline.copyWith(color: Colors.white),
             ),
-            if (requestBody != null && requestBody != 'null') ...[
+            if (requestBodyIsJson) ...[
               const Spacer(),
               _CopyButton(onPressed: () => onCopyRequestBody(requestBody)),
             ]
           ],
         ),
         const SizedBox(height: 8),
-        if (requestBody != null && requestBody != 'null')
+        if (requestBodyIsJson)
           _ColoredJson(jsonData: requestBody)
+        else if (requestBodyIsPresent)
+          SelectableText(requestBody, style: AppTypography.body.copyWith(color: Colors.white))
         else
           Text(
             'No request body',
@@ -345,6 +350,8 @@ class _ResponseTab extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final responseBody = log.responseBody;
+    final responseBodyIsPresent = responseBody != null && responseBody != 'null' && responseBody.isNotEmpty;
+    final responseBodyIsJson = responseBodyIsPresent && JsonUtils.isJson(responseBody);
     final headers = log.responseHeaders?.entries ?? {};
 
     return _ScrollableTab(
@@ -386,15 +393,17 @@ class _ResponseTab extends StatelessWidget {
               'Body:',
               style: AppTypography.headline.copyWith(color: Colors.white),
             ),
-            if (responseBody != null && responseBody != 'null') ...[
+            if (responseBodyIsJson) ...[
               const Spacer(),
               _CopyButton(onPressed: () => onCopyResponseBody(responseBody)),
             ]
           ],
         ),
         const SizedBox(height: 8),
-        if (responseBody != null && responseBody != 'null')
+        if (responseBodyIsJson)
           _ColoredJson(jsonData: responseBody)
+        else if (responseBodyIsPresent)
+          SelectableText(responseBody, style: AppTypography.body.copyWith(color: Colors.white))
         else
           Text(
             'No response body',

--- a/lib/src/network_logs/widget/network_logs_details_page.dart
+++ b/lib/src/network_logs/widget/network_logs_details_page.dart
@@ -326,7 +326,7 @@ class _RequestTab extends StatelessWidget {
         if (requestBodyIsJson)
           _ColoredJson(jsonData: requestBody)
         else if (requestBodyIsPresent)
-          SelectableText(requestBody, style: AppTypography.body.copyWith(color: Colors.white))
+          SelectableText(requestBody, style: AppTypography.body.copyWith(color: Colors.white70))
         else
           Text(
             'No request body',
@@ -403,7 +403,7 @@ class _ResponseTab extends StatelessWidget {
         if (responseBodyIsJson)
           _ColoredJson(jsonData: responseBody)
         else if (responseBodyIsPresent)
-          SelectableText(responseBody, style: AppTypography.body.copyWith(color: Colors.white))
+          SelectableText(responseBody, style: AppTypography.body.copyWith(color: Colors.white70))
         else
           Text(
             'No response body',

--- a/lib/src/utils/json_utils.dart
+++ b/lib/src/utils/json_utils.dart
@@ -1,0 +1,12 @@
+import 'dart:convert';
+
+final class JsonUtils {
+  static bool isJson(String data) {
+    try {
+      final decoded = jsonDecode(data);
+      return decoded is Map || decoded is List;
+    } catch (e) {
+      return false;
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: chili_debug_view
 description: Flutter debug view for checking network logs, response time and sharing them outside of app
 homepage: https://github.com/ChiliLabs/chili_debug_view
-version: 1.3.0
+version: 1.3.1
 
 topics:
   - debug


### PR DESCRIPTION
Some requests and responses will have non-JSON bodies (like x-www-form-urlencoded, or even straight up HTML).
Added JSON check, which will determine if we use `ColoredJson` or regular `SelectableText`

Also added missing prettified headers for error response (they were already added for regular request/response)